### PR TITLE
Capitalize app name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "notes",
-  "name": "notes",
+  "short_name": "Notes",
+  "name": "Notes",
   "description" : "An offline-capable notes app, using localStorage and ServiceWorker",
   "display": "standalone",
   "orientation": "portrait",


### PR DESCRIPTION
The name of the app looks strange in the lowercase compared to other apps typically on the homescreen.